### PR TITLE
adjust ownership / author info

### DIFF
--- a/.github/codeowners
+++ b/.github/codeowners
@@ -1,4 +1,4 @@
 # Use this file to define individuals or teams that are responsible for code in a repository.
 # Read more: <https://help.github.com/articles/about-codeowners/>
 
-* @itsthejoker @szymonhab @altieres-spoton @brianpatrickoreilly
+* @SpotOnInc/theseus @SpotOnInc/open-source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "snowfake-db"
 version = "0.1.4"
 description = "An easy way to mock Snowflake connections in Python!"
-authors = ["Joe Kaufeld <jkaufeld@spoton.com>"]
+authors = ["Joe Kaufeld <jkaufeld@spoton.com>", "SpotOn <opensource@spoton.com>"]
 readme = "README.md"
 packages = [{include = "snowfake_db"}]
 


### PR DESCRIPTION
<!-- Put the GitHub issue number or Jira ticket ID here! -->
Relates to https://github.com/SpotOnInc/snowfake/issues/7

## Description:
<!-- What does this PR do? Why are we opening it? -->

Adjust codeowners to be team-based, add SpotOn generic open source contact to author in pyproject.toml

## Important Notes:
<!-- Is there anything we need to know while reviewing? -->

Tagging the open source group as reviewer on this, since they will be pinged on future PRs in this repo based on this PR.

I changed a couple repo settings to be in alignment with what I consider best practices, the main one relevant to this is requiring a codeowner to approve PRs before merge. See the screenshot.

## Screenshots:

<!-- Got any before / after shots to show off how awesome this change is? -->

![image](https://user-images.githubusercontent.com/50844842/211559779-d9cea828-1551-46c3-ade2-18a1f006ee53.png)
