### PR TITLE
:green_heart: fix wrongly-scoped token

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -22,7 +22,7 @@ jobs:
           #
           # ALLOWING WORKFLOWS TO TRIGGER OTHER WORKFLOWS CAN POTENTIALLY CREATE A LOOP!
           # ALWAYS VERIFY THE ACTION YOU ARE CREATING DOES NOT HAVE THIS POSSIBILITY!
-          GITHUB_TOKEN: '${{ secrets.ADMIN_GITHUB_TOKEN }}'
+          GITHUB_TOKEN: '${{ secrets.PAT }}'
 
       - run: echo 'Merge conflicts found! Some PRs have not been updated.'
         if: ${{ steps.autoupdate.outputs.conflicted }}

--- a/.github/workflows/update_version.yml
+++ b/.github/workflows/update_version.yml
@@ -30,7 +30,7 @@ jobs:
           #
           # ALLOWING WORKFLOWS TO TRIGGER OTHER WORKFLOWS CAN POTENTIALLY CREATE A LOOP!
           # ALWAYS VERIFY THE ACTION YOU ARE CREATING DOES NOT HAVE THIS POSSIBILITY!
-          token: '${{ secrets.ADMIN_GITHUB_TOKEN }}'
+          token: '${{ secrets.PAT }}'
 
       - name: Set up Python 3.11.x
         uses: actions/setup-python@v4
@@ -113,7 +113,7 @@ jobs:
         #
         # ALLOWING WORKFLOWS TO TRIGGER OTHER WORKFLOWS CAN POTENTIALLY CREATE A LOOP!
         # ALWAYS VERIFY THE ACTION YOU ARE CREATING DOES NOT HAVE THIS POSSIBILITY!
-        token: '${{ secrets.ADMIN_GITHUB_TOKEN }}'
+        token: '${{ secrets.PAT }}'
 
     - name: Update version number
       run: poetry version "${{ env.new_version }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asbestos"
-version = "1.0.0"
+version = "1.0.1"
 description = "An easy way to mock Snowflake connections in Python!"
 authors = ["Joe Kaufeld <jkaufeld@spoton.com>", "SpotOn <opensource@spoton.com>"]
 readme = "README.md"


### PR DESCRIPTION
<!-- Put the GitHub issue number or Jira ticket ID here! -->
Ticket: N/a

## Description:
<!-- What does this PR do? Why are we opening it? -->

The admin secret is only scoped for internal usage, so this attempts to replace it with a PAT.

<!--
Last minute questions to consider -- if the answer is 'yes' to any of these, please make sure to note that above:

- Does this change require an update to any other applications or third-party libraries?
- Is this change blocked by anything else?
- Does this change require actions outside this PR? For example, updating secrets or keys?
-->