### PR TITLE
:truck: change pypi name to asbestos-snow

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ with snowflake_cursor() as cursor:
 ## Installation:
 
 ```shell
-poetry add asbestos
+poetry add asbestos-snow
 ```
+
+The installation name is slightly different from the usage name due to a squatter on PyPI; with luck, we will be able to finish the name requisition process to be able to use `asbestos` soon. If you're interested, you can [see how well that's going here](https://github.com/pypi/support/issues/2621).
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ with snowflake_cursor() as cursor:
 poetry add asbestos-snow
 ```
 
-The installation name is slightly different from the usage name due to a squatter on PyPI; with luck, we will be able to finish the name requisition process to be able to use `asbestos` soon. If you're interested, you can [see how well that's going here](https://github.com/pypi/support/issues/2621).
+The installation name is slightly different from the usage name due to someone claiming the name with no releases on PyPI; with luck, we will be able to finish the name requisition process to be able to use `asbestos` soon. If you're interested, you can [see how well that's going here](https://github.com/pypi/support/issues/2621).
 
 ## Docs
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ A mock data system for [Snowflake](https://www.snowflake.com/en/). Test your cod
 
 ## Installation
 
-Grab it from PyPi with `pip install asbestos` or `poetry add asbestos`. This is a pure Python package, so it has no required dependencies of its own. Asbestos takes advantage of modern language features and only supports Python 3.10+.
+Grab it from PyPI with `pip install asbestos-snow` or `poetry add asbestos-snow`. This is a pure Python package and has no required dependencies of its own. Asbestos takes advantage of modern language features and only supports Python 3.10+.
 
 !!! note
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
-name = "asbestos"
-version = "1.0.3"
+name = "asbestos-snow"
+version = "1.0.4"
 description = "An easy way to mock Snowflake connections in Python!"
 authors = ["Joe Kaufeld <jkaufeld@spoton.com>", "SpotOn <opensource@spoton.com>"]
 readme = "README.md"


### PR DESCRIPTION
<!-- Put the GitHub issue number or Jira ticket ID here! -->
Ticket: https://github.com/pypi/support/issues/2621

## Description:
<!-- What does this PR do? Why are we opening it? -->

The `asbestos` package name on PyPI is currently taken by someone with no packages published, so we've started the process of requesting the name for our use. However, this process can take a very long time -- >8-10 weeks. Since we want to start using this immediately, we've elected to do the following:

* rename the _installer name_ of `asbestos` to `asbestos-snow`
* keep everything else the same (use with `import asbestos`, etc)
* wait until we hear movement on the name request
* if / when the name request goes through, we will:
  * move this package to `asbestos`
  * publish an alias package for 6 months to a year at `asbestos-snow` that simply installs the latest version of `asbestos`, à la [django rest framework's redirect](https://pypi.org/project/django-rest-framework/)
  * remove the redirect package after enough time has passed

This PR just renames the install name to `asbestos-snow` and updates documentation related to installation.