### PR TITLE
:sparkles: add force_pagination_size and update docs

### DIFF
--- a/asbestos/asbestos.py
+++ b/asbestos/asbestos.py
@@ -340,7 +340,7 @@ class AsbestosCursor:
         config.register(query="A", response=[{'a':1}, {'b': 2}])
         with asbestos_cursor() as cursor:
             cursor.execute("A")
-            resp = cursor.fetchall()
+            resp = cursor.fetchone()
 
         # resp = {'a':1}
         ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asbestos-snow"
-version = "1.0.4"
+version = "1.1.0"
 description = "An easy way to mock Snowflake connections in Python!"
 authors = ["Joe Kaufeld <jkaufeld@spoton.com>", "SpotOn <opensource@spoton.com>"]
 readme = "README.md"


### PR DESCRIPTION
<!-- Put the GitHub issue number or Jira ticket ID here! -->
Ticket: #29 

## Description:
<!-- What does this PR do? Why are we opening it? -->

To fix an internal issue brought up by @szymonhab, this PR allows you to force a pagination response size for `fetchmany` and updates the tests to cover a few missing cases and the new additions.


## Checklist:

- [x] Code Quality
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation

<!--
Last minute questions to consider -- if the answer is 'yes' to any of these, please make sure to note that above:

- Does this change require an update to any other applications or third-party libraries?
- Is this change blocked by anything else?
- Does this change require actions outside this PR? For example, updating secrets or keys?
-->