### PR TITLE
✨ Rename asbestos-snow to asbestos

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -66,3 +66,12 @@ jobs:
 
       - name: Push to PyPI
         run: poetry publish --username ${{ secrets.PYPI_USERNAME }} --password ${{ secrets.PYPI_TOKEN }}
+
+      - name: Build stub package
+        run: |
+          cd stub
+          sed -i -e "s/?????/${{ env.version_number }}/g" pyproject.toml
+          poetry build
+
+      - name: Push to PyPI
+        run: poetry publish --username ${{ secrets.PYPI_USERNAME }} --password ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -33,10 +33,8 @@ with snowflake_cursor() as cursor:
 ## Installation:
 
 ```shell
-poetry add asbestos-snow
+poetry add asbestos
 ```
-
-The installation name is slightly different from the usage name due to someone claiming the name with no releases on PyPI; with luck, we will be able to finish the name requisition process to be able to use `asbestos` soon. If you're interested, you can [see how well that's going here](https://github.com/pypi/support/issues/2621).
 
 ## Docs
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ A mock data system for [Snowflake](https://www.snowflake.com/en/). Test your cod
 
 ## Installation
 
-Grab it from PyPI with `pip install asbestos-snow` or `poetry add asbestos-snow`. This is a pure Python package and has no required dependencies of its own. Asbestos takes advantage of modern language features and only supports Python 3.9+.
+Grab it from PyPI with `pip install asbestos` or `poetry add asbestos`. This is a pure Python package and has no required dependencies of its own. Asbestos takes advantage of modern language features and only supports Python 3.9+.
 
 !!! note
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [tool.poetry]
-name = "asbestos-snow"
+name = "asbestos"
 version = "1.4.0"
 description = "An easy way to mock Snowflake connections in Python!"
 authors = ["Joe Kaufeld <jkaufeld@spoton.com>", "SpotOn <opensource@spoton.com>"]
 readme = "README.md"
 packages = [{include = "asbestos"}]
+exclude = ["stub"]
 repository = "https://github.com/spotoninc/asbestos"
 documentation = "https://spotoninc.github.io/asbestos"
 classifiers = [

--- a/stub/README.md
+++ b/stub/README.md
@@ -1,0 +1,9 @@
+# asbestos-snow
+
+This is the old location of the `asbestos` project for mocking SnowflakeDB calls in your application. Installing this stub will install the current version of `asbestos`, but you should update your requirements to install `asbestos` instead of `asbestos-snow`.
+
+The new home of the project is here: https://pypi.org/project/asbestos/
+
+## Note for developers
+
+This directory is a self-contained stub package that is automatically released when a new version of `asbestos` is released. Do not touch anything in here and do not delete this directory.

--- a/stub/pyproject.toml
+++ b/stub/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asbestos-snow"
-version = "?????"
+version = "?????"  # this will be replaced in the CI pipeline
 packages = [{include = "empty"}]
 description = "asbestos-snow has moved to asbestos: https://pypi.org/project/asbestos/"
 authors = ["Joe Kaufeld <jkaufeld@spoton.com>", "SpotOn <opensource@spoton.com>"]
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-asbestos = "?????"
+asbestos = "?????"  # this will be replaced in the CI pipeline
 
 [build-system]
 requires = ["poetry-core"]

--- a/stub/pyproject.toml
+++ b/stub/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "asbestos-snow"
+version = "?????"
+packages = [{include = "empty"}]
+description = "asbestos-snow has moved to asbestos: https://pypi.org/project/asbestos/"
+authors = ["Joe Kaufeld <jkaufeld@spoton.com>", "SpotOn <opensource@spoton.com>"]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.9"
+asbestos = "?????"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
<!-- Put the GitHub issue number or Jira ticket ID here! -->
Ticket: #45 

## Description:
<!-- What does this PR do? Why are we opening it? -->

We've recently gotten control of the `asbestos` name on PyPI, so we want to migrate the package to the new name. This causes an issue; namely, we want folks to be able to continue using the existing setup under its current name, `asbestos-snow`, without interruption until they have a chance to update.

Taking a page from Django Rest Framework's book, we solve this by creating a stub package that just points at the real one and uploading that in its place. The way this works is:

* during release process, take note of the version number
* build `asbestos`
  * push build to GitHub Releases
  * push build to PyPI
* move to the `stub` directory
* use `sed` to insert the current version number into the pyproject.toml file, both as the current version of the package and the requested version of `asbestos` to install
* build `asbestos-snow` with the contents of the empty stub package
* push `asbestos-snow` to pypi

This will ensure that we have two projects that are always in sync and will also allow code that relies on `asbestos-snow` to continue receiving updates without any additional work on our part.

## Important Notes:
<!-- Is there anything we need to know while reviewing? -->

Normally, we would also want to display some kind of deprecation notice on install, but poetry explicitly does not support this. Therefore, I've opted to just ignore it and move on.

## Checklist:

- [x] Code Quality
- [ ] Tests (if applicable)
- [x] Success Criteria Met
- [x] Inline Documentation

<!--
Last minute questions to consider -- if the answer is 'yes' to any of these, please make sure to note that above:

- Does this change require an update to any other applications or third-party libraries?
- Is this change blocked by anything else?
- Does this change require actions outside this PR? For example, updating secrets or keys?
-->
